### PR TITLE
Bumping subversion 0.10.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
 group = "com.amazon.opendistroforelasticsearch"
 // Increment the final digit when there's a new plugin versions for the same opendistro version
 // Reset the final digit to 0 when upgrading to a new opendistro version
-version = "${opendistroVersion}.0" + (isSnapshot ? "-SNAPSHOT" : "")
+version = "${opendistroVersion}.1" + (isSnapshot ? "-SNAPSHOT" : "")
 
 
 if (!project.hasProperty("archivePath")) {

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.10.0.0</version>
+    <version>0.10.0.1</version>
     <packaging>pom</packaging>
 
     <name>Open Distro For Elasticsearch Security Parent</name>
@@ -399,6 +399,6 @@
         <url>https://github.com/opendistro-for-elasticsearch/security-parent</url>
         <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</connection>
         <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</developerConnection>
-        <tag>v0.10.0.0</tag>
+        <tag>v0.10.0.1</tag>
     </scm>
 </project>


### PR DESCRIPTION
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 4.14
[INFO] os.detected.version.major: 4
[INFO] os.detected.version.minor: 14
[INFO] os.detected.release: debian
[INFO] os.detected.release.version: 9
[INFO] os.detected.release.like.debian: true
[INFO] os.detected.classifier: linux-x86_64
[INFO]
[INFO] --< com.amazon.opendistroforelasticsearch:opendistro_security_parent >--
[INFO] Building Open Distro For Elasticsearch Security Parent 0.10.0.1
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-java) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:revision (get-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_parent ---
[INFO] Installing /Opendistro/tc-security-0.10/security-parent/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_parent/0.10.0.1/opendistro_security_parent-0.10.0.1.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------