### PR TITLE
Bumping subversion 0.10.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
 group = "com.amazon.opendistroforelasticsearch"
 // Increment the final digit when there's a new plugin versions for the same opendistro version
 // Reset the final digit to 0 when upgrading to a new opendistro version
-version = "${opendistroVersion}.1" + (isSnapshot ? "-SNAPSHOT" : "")
+version = "${opendistroVersion}.2" + (isSnapshot ? "-SNAPSHOT" : "")
 
 
 if (!project.hasProperty("archivePath")) {

--- a/opendistro-elasticsearch-security.release-notes
+++ b/opendistro-elasticsearch-security.release-notes
@@ -1,3 +1,17 @@
+## 2019-09-06, Version 0.10.0.2 (Current)
+
+- Add 3 new default read only roles to easily allow integration with the opendistro alerting plugin in security package
+- Add the ability to block indices and index patterns to certain roles, adding another level of protection for these indices in security and security advanced modules packages
+- Initialize opendistro index if injected user enabled in security package
+
+## 2019-08-21, Version 0.10.0.1
+
+- Fix API path naming issue in security and security advanced modules packages
+
+## 2019-07-25, Version 0.10.0.0
+
+- Support For Elasticsearch 6.8
+
 ## 2019-07-15, Version 0.9.0.1
 
 - Add PUT and PATCH method for securityconfig

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.2</version>
     <packaging>pom</packaging>
 
     <name>Open Distro For Elasticsearch Security Parent</name>
@@ -399,6 +399,6 @@
         <url>https://github.com/opendistro-for-elasticsearch/security-parent</url>
         <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</connection>
         <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</developerConnection>
-        <tag>v0.10.0.1</tag>
+        <tag>v0.10.0.2</tag>
     </scm>
 </project>


### PR DESCRIPTION
Update subversion tags.

[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 4.14
[INFO] os.detected.version.major: 4
[INFO] os.detected.version.minor: 14
[INFO] os.detected.release: debian
[INFO] os.detected.release.version: 9
[INFO] os.detected.release.like.debian: true
[INFO] os.detected.classifier: linux-x86_64
[INFO]
[INFO] --< com.amazon.opendistroforelasticsearch:opendistro_security_parent >--
[INFO] Building Open Distro For Elasticsearch Security Parent 0.10.0.2
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-java) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:revision (get-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_parent ---
[INFO] Installing /Opendistro/security-parent/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_parent/0.10.0.2/opendistro_security_parent-0.10.0.2.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------