### PR TITLE
Support for ES 7.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 buildDir = 'gradle-build'
 
 ext {
-    opendistroVersion = '1.2.0'
+    opendistroVersion = '1.2.1'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -39,7 +39,7 @@ ospackage {
     fileMode 0644
     dirMode 0755
 
-    requires('elasticsearch-oss', "7.2.0", EQUAL)
+    requires('elasticsearch-oss', "7.2.1", EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/opendistro-elasticsearch-security-parent.release-notes
+++ b/opendistro-elasticsearch-security-parent.release-notes
@@ -1,6 +1,10 @@
-## 2019-08-07, Version 1.2.0.0 (Current)
+## 2019-10-10, Version 1.2.1.0 (Current)
 
--Support For Elasticsearch 7.2
+- Support for Elasticsearch 7.2.1
+
+## 2019-08-07, Version 1.2.0.0
+
+- Support For Elasticsearch 7.2.0
 
 ## 2019-06-21, Version 1.1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro_security_parent</artifactId>
-    <version>1.2.0.0</version>
+    <version>1.2.1.0</version>
     <packaging>pom</packaging>
 
     <name>Open Distro For Elasticsearch Security Parent</name>
@@ -409,6 +409,6 @@
         <url>https://github.com/opendistro-for-elasticsearch/security-parent</url>
         <connection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</connection>
         <developerConnection>scm:git:git@github.com:opendistro-for-elasticsearch/security-parent.git</developerConnection>
-        <tag>v1.2.0.0</tag>
+        <tag>v1.2.1.0</tag>
     </scm>
 </project>


### PR DESCRIPTION
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: x86_64
[INFO] os.detected.version: 4.14
[INFO] os.detected.version.major: 4
[INFO] os.detected.version.minor: 14
[INFO] os.detected.release: debian
[INFO] os.detected.release.version: 9
[INFO] os.detected.release.like.debian: true
[INFO] os.detected.classifier: linux-x86_64
[INFO]
[INFO] --< com.amazon.opendistroforelasticsearch:opendistro_security_parent >--
[INFO] Building Open Distro For Elasticsearch Security Parent 1.2.1.0
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-java) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:revision (get-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:validateRevision (validate-the-git-infos) @ opendistro_security_parent ---
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_parent ---
[INFO] Installing /Opendistro/security-parent/pom.xml to /root/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_parent/1.2.1.0/opendistro_security_parent-1.2.1.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------