### PR TITLE
Deprecating security-parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 [![CI](https://github.com/opendistro-for-elasticsearch/security-parent/workflows/CI/badge.svg?branch=master)](https://github.com/opendistro-for-elasticsearch/security-parent/actions)
 
+## Note:
+
+* **Deprecated as of Opendistro version 1.0**
+
 # Open Distro For Elasticsearch Security Parent
 
 Open Distro for Elasticsearch Security Parent is the parent repo for the Open Distro for Elasticsearch security plugin repositories, including:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Note:
 
-* **Deprecated as of Opendistro version 1.0**
+* **Deprecated as of Opendistro version 1.4.x.x**
 
 # Open Distro For Elasticsearch Security Parent
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 [![CI](https://github.com/opendistro-for-elasticsearch/security-parent/workflows/CI/badge.svg?branch=master)](https://github.com/opendistro-for-elasticsearch/security-parent/actions)
 
-## Note:
+## Deprecated as of Opendistro version 1.4:
 
-* **Deprecated as of Opendistro version 1.4.x.x**
+* Security-advanced-modules and security-parent have been merged into security.
 
 # Open Distro For Elasticsearch Security Parent
 


### PR DESCRIPTION
Security-advanced-modules and security-parent have been merged into security.  
